### PR TITLE
event.QueryAppender changed to event.IQuery

### DIFF
--- a/logrusbun.go
+++ b/logrusbun.go
@@ -200,7 +200,7 @@ func (h *QueryHook) AfterQuery(ctx context.Context, event *bun.QueryEvent) {
 
 // taken from bun
 func eventOperation(event *bun.QueryEvent) string {
-	switch event.QueryAppender.(type) {
+	switch event.IQuery.(type) {
 	case *bun.SelectQuery:
 		return "SELECT"
 	case *bun.InsertQuery:


### PR DESCRIPTION
definition of bun.QueryEvent has been changed, `QueryAppender` changed to `IQuery`